### PR TITLE
Fix for blender 3.1

### DIFF
--- a/sprytile_gui.py
+++ b/sprytile_gui.py
@@ -486,10 +486,10 @@ class VIEW3D_OP_SprytileGui(bpy.types.Operator):
                     max(grid_pos.y, VIEW3D_OP_SprytileGui.sel_start.y)
                 ))
 
-                tilegrid.tile_selection[0] = sel_min.x
-                tilegrid.tile_selection[1] = sel_min.y
-                tilegrid.tile_selection[2] = (sel_max.x - sel_min.x) + 1
-                tilegrid.tile_selection[3] = (sel_max.y - sel_min.y) + 1
+                tilegrid.tile_selection[0] = int(sel_min.x)
+                tilegrid.tile_selection[1] = int(sel_min.y)
+                tilegrid.tile_selection[2] = int((sel_max.x - sel_min.x) + 1)
+                tilegrid.tile_selection[3] = int((sel_max.y - sel_min.y) + 1)
 
             do_release = event.type in {'LEFTMOUSE', 'MIDDLEMOUSE'} and event.value == 'RELEASE'
             if do_release and (VIEW3D_OP_SprytileGui.is_selecting or VIEW3D_OP_SprytileGui.is_moving):

--- a/sprytile_modal.py
+++ b/sprytile_modal.py
@@ -456,7 +456,7 @@ class VIEW3D_OP_SprytileModalTool(bpy.types.Operator):
             el.index_update()
             el.ensure_lookup_table()
 
-        bmesh.update_edit_mesh(context.object.data, True, True)
+        bmesh.update_edit_mesh(context.object.data)
 
         # Update the collision BVHTree with new data
         self.refresh_mesh = True
@@ -927,7 +927,7 @@ class VIEW3D_OP_SprytileModalTool(bpy.types.Operator):
         self.tree = None
         self.tools = None
         if context.object.mode == 'EDIT':
-            bmesh.update_edit_mesh(context.object.data, True, True)
+            bmesh.update_edit_mesh(context.object.data)
 
 
 # module classes


### PR DESCRIPTION
Blender 3.1 requires changes in sprytile_gui for the tileset grid cast to int, bmesh api changed to only accept one argument, requires changes in sprytile_modal. 